### PR TITLE
Add support for enabling high DPI

### DIFF
--- a/src/native/macosx/org_lwjgl_opengl_Display.m
+++ b/src/native/macosx/org_lwjgl_opengl_Display.m
@@ -77,7 +77,11 @@ static NSUInteger lastModifierFlags = 0;
     // Inform the view of its parent window info;
 	[window_info->view setParent:window_info];
 	
-	[window_info->view setWantsBestResolutionOpenGLSurface:NO];
+	if (window_info->enableHighDPI) {
+		[window_info->view setWantsBestResolutionOpenGLSurface:YES];
+	} else {
+		[window_info->view setWantsBestResolutionOpenGLSurface:NO];
+	}
 	
 	// set nsapp delegate for catching app quit events
 	[NSApp setDelegate:window_info->view];

--- a/src/native/macosx/org_lwjgl_opengl_Display.m
+++ b/src/native/macosx/org_lwjgl_opengl_Display.m
@@ -77,7 +77,7 @@ static NSUInteger lastModifierFlags = 0;
     // Inform the view of its parent window info;
 	[window_info->view setParent:window_info];
 	
-	if (window_info->enableHighDPI) {
+	if (window_info->enableHighDPI && !window_info->fullscreen) {
 		[window_info->view setWantsBestResolutionOpenGLSurface:YES];
 	} else {
 		[window_info->view setWantsBestResolutionOpenGLSurface:NO];


### PR DESCRIPTION
I am currently working on a mod that allows Minecraft versions prior to 1.13 to take advantage of high DPI screens on macOS. To accomplish this I am setting the `org.lwjgl.opengl.Display.enableHighDPI` property to true on startup and then injecting calls to `Display.getPixelScaleFactor()` into Minecraft's code to scale the GUI properly. This works fine when using Mojang's LWJGL 2 libraries with x86_64 java, but when using the binaries provided by this repository with aarch64 java my mod ceases to work. The Minecraft window will only display the bottom left corner of the framebuffer.

After some research, I figured out that this is caused by eed74ff. I assume that this change was made to fix the issue with macOS defaulting to a high DPI framebuffer (I discovered that issue when I reverted this commit to see what would happen). That change is fine for normal Minecraft, because it doesn't make use of LWJGL 2's high DPI mode, but it prevents my mod from working.

This PR changes that line so that instead of always setting `setWantsBestResolutionOpenGLSurface` to `NO`, it'll set it to `YES` if high DPI mode is enabled and `NO` if it isn't. This should fix my issue while maintaining compatibility with everyone else. Let me know if you see any problems with my solution.